### PR TITLE
Add in priority lookup in parent/child themes for existing better-search...

### DIFF
--- a/better-search.php
+++ b/better-search.php
@@ -100,11 +100,19 @@ function bsearch_template_redirect() {
 	add_action( 'wp_head', 'bsearch_head' );
 	add_filter( 'wp_title', 'bsearch_title' );
 
-	// If there is a template file then we use it
-	$exists = file_exists( get_stylesheet_directory() . '/better-search-template.php' );
-	if ( $exists ) {
-		include_once( get_stylesheet_directory() . '/better-search-template.php' );
-		exit;
+	// If there is a template file within the parent or child theme then we use it
+	$priority_template_lookup = array(
+		get_stylesheet_directory() . '/better-search-template.php',
+		get_template_directory() . '/better-search-template.php'
+	);
+
+	foreach( $priority_template_lookup as $exists ) {
+
+		if( file_exists( $exists ) ) {
+
+			include_once( $exists );
+			exit;
+		}
 	}
 
 	// Create a template here if there is a template


### PR DESCRIPTION
Hi!

Huge fan of Better Search (use it on a LOT of projects)... Noticed you added the ability to load in a search template (better-search-template.php) - GREAT feature!

I use both a parent and child theme for most of our WP work and would really like to include a default template within my parent theme if one does not exist within my child theme. I added a small priority look-up for both the child and parent theme locations (get_stylesheet_directory() for the child then get_template_directory() for the parent).

I would really appreciate your consideration in including this small change within your plugin for future versions =)

Thank you again for your great plugins and thanks for your consideration!!!

Sincerely,
Folkhack
