### PR TITLE
update 2nd argument of get_bsearch_results

### DIFF
--- a/better-search.php
+++ b/better-search.php
@@ -81,7 +81,7 @@ add_action( 'plugins_loaded', 'bsearch_lang_init' );
  * @param	int|string $limit			Maximum number of search results.
  * @return	string     Search results
  */
-function get_bsearch_results( $search_query = '', $limit ) {
+function get_bsearch_results( $search_query = '', $limit = '' ) {
 	global $wpdb, $bsearch_settings;
 
 	if ( ! ( $limit ) ) {


### PR DESCRIPTION
update 2nd argument of get_bsearch_results to have default. since you can "optionally" pass the 1st argument, the second should also be optional.
this meets the check on line 87 as well.